### PR TITLE
Specify alternate urbandictionary definitions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ bs4
 slackclient
 translate
 requests
+yahoo_finance


### PR DESCRIPTION
usage example:
```
@botiana define douchebaggery                alt:1
```
```
@botiana define sharknado alt:1
```

Digits work as usual:
```
@botiana define sharknado 2
```