### PR TITLE
Add support for custom commands local to your slack instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Several other items can be configured by setting environment variables:
 more are available, consult legacy_modules.py.
 
 #### Data
-Botiana loads local data from a yaml file: data/data.yaml
+Botiana loads local data from a yaml file: `data/data.yaml`
 
 If you're running the bot in kubernetes or in docker you can mount your file from a ConfigMap or a volume mount.
+
 `docker run -v "/path/to/my/data.yaml":"/usr/local/botiana/data/data.yaml"  -e token=$token botiana`
 
 #### Keywords & Reactions
@@ -48,6 +49,7 @@ Botiana can support you. You'll need to have a file in the path with the main pr
 1. You must define an array  `local_commands = ['tru', 'lunch']` that defines what commands in local`local_modules.py` are actionable by botiana. 
 
 If you're running the bot in kubernetes or in docker you can mount your file from a ConfigMap or a volume mount.
+
 `docker run -v "/path/to/my/cool_modules.py":"/usr/local/botiana/local_modules.py"  -e token=$token botiana`
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -29,11 +29,26 @@ more are available, consult legacy_modules.py.
 #### Data
 Botiana loads local data from a yaml file: data/data.yaml
 
+If you're running the bot in kubernetes or in docker you can mount your file from a ConfigMap or a volume mount.
+`docker run -v "/path/to/my/data.yaml":"/usr/local/botiana/data/data.yaml"  -e token=$token botiana`
+
 #### Keywords & Reactions
 Keywords, responses and reactions can occur in specific channels, or all channels. Configure this in the data.yaml file.
 
 #### Systems Administrator Dictionary
 Local dictionary entries can be created for lookup. Configure this in the data.yaml file.
+
+#### Local Modules
+There may arise a time when you want to have custom modules defined for the bot that don't really belong in this repo. Maybe your team commonly translates English to Russian and you're all getting tired of typeing `tr:en|ru`. You could make a local module that defines `tru` as a shortcut. You may want something that calls an internal API to return the lunch selections for the day in the cafeteria. :shrug: You do you. 
+
+Botiana can support you. You'll need to have a file in the path with the main program named `local_modules.py`. 
+
+##### File Requirements
+1. All custom commands must start with a letter, not underscores, as the bot rejects underscore commands.
+1. You must define an array  `local_commands = ['tru', 'lunch']` that defines what commands in local`local_modules.py` are actionable by botiana. 
+
+If you're running the bot in kubernetes or in docker you can mount your file from a ConfigMap or a volume mount.
+`docker run -v "/path/to/my/cool_modules.py":"/usr/local/botiana/local_modules.py"  -e token=$token botiana`
 
 ### Build
 `docker build . -t botiana`

--- a/message_router.py
+++ b/message_router.py
@@ -9,8 +9,23 @@ from slack_commands import __send_message
 # noinspection PyUnresolvedReferences
 from legacy_modules import eight_ball, wiki, define, memelist, meme, __trans, rtfm
 
+try:
+    from local_modules import *
+except ImportError:
+    logger('warn', 'no local modules to import')
+
+
 
 def message_router(variables, botname, evt, command, message):
+    all_commands = commands
+    
+    try: 
+        if local_commands:
+            all_commands += local_commands
+    except NameError:
+        logger('info', 'no local module commands were defined')
+        pass
+
     if "type" in evt and evt["type"] == "message" and "text" in evt:
         # Channel/Group Invites
         # Slack does something along the lines of "@bot has been added to channel"
@@ -44,7 +59,7 @@ def message_router(variables, botname, evt, command, message):
             logger('crit', "Killed by human")
             sys.exit(0)
         else:
-            if command in cmnds:
+            if command in all_commands:
                 # http://stackoverflow.com/a/16683842/436190
                 # stop the madness
                 globals()[command](variables, messagedetails)

--- a/message_router.py
+++ b/message_router.py
@@ -15,7 +15,6 @@ except ImportError:
     logger('warn', 'no local modules to import')
 
 
-
 def message_router(variables, botname, evt, command, message):
     all_commands = commands
     

--- a/settings.py
+++ b/settings.py
@@ -15,6 +15,9 @@ MAX_TRANSLATE_LENGTH = 250
 # enabled commands
 commands = ['eight_ball', 'define', 'wiki', 'memelist', 'meme', 'rtfm']
 
+# enabled local commands
+local_commands = []
+
 # bot avatar
 icon_default = ('https://upload.wikimedia.org/wikipedia/' +
                 'commons/thumb/7/7e/Hammer_and_sickle.svg/1024px-Hammer_and_sickle.svg.png')

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,7 @@ LOG_LEVEL = 'crit'
 MAX_TRANSLATE_LENGTH = 250
 
 # enabled commands
-cmnds = ['eight_ball', 'define', 'wiki', 'memelist', 'meme', 'rtfm']
+commands = ['eight_ball', 'define', 'wiki', 'memelist', 'meme', 'rtfm']
 
 # bot avatar
 icon_default = ('https://upload.wikimedia.org/wikipedia/' +

--- a/slack_commands.py
+++ b/slack_commands.py
@@ -8,7 +8,6 @@ def __send_snippet(sc, text, channel, thread_ts="", initial_comment='', title='-
     # Required slackclient, channel, thread_ts
     # thread_ts if this is a thread response
     logger('info', initial_comment)
-    res = None
     try:
         res = sc.api_call('files.upload',
                           channels=channel,
@@ -33,7 +32,6 @@ def __send_message(sc, text, channel, thread_ts="", icon_url='ru', emoji='null')
     # icon_url to override default, set this to 'emoji' override with an emoji
     # emoji set this to a valid emoji and ensure icon_url='emoji'
     try:
-        res = None
         if "emoji" in icon_url:
             res = sc.api_call('chat.postMessage',
                               username=BOT_NAME,
@@ -97,7 +95,6 @@ def __send_ephemeral(sc, text, channel, caller):
 
 def __set_topic(sc, new_topic, channel):
     try:
-        res = None
         if channel.startswith("G"):
             res = sc.api_call('groups.setTopic',
                               channel=channel,


### PR DESCRIPTION
This allows us to build and publish a Docker image to Docker Hub that can be used by anyone by simply mounting their desired `data/data.yaml` and `local_modules.py` into the container.