### PR TITLE
/usr/bin/python3 is the correct path after moving to arm

### DIFF
--- a/botiana.py
+++ b/botiana.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 # Python 3, dev on debian 9, intending to run in alpine / python official image
 
 import threading

--- a/common.py
+++ b/common.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 # Common functions
 from settings import *

--- a/keywords.py
+++ b/keywords.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 from random import randint
 import random

--- a/legacy_modules.py
+++ b/legacy_modules.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/python
 
 import random
 import requests

--- a/message_router.py
+++ b/message_router.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 
 import sys

--- a/slack_commands.py
+++ b/slack_commands.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 from common import logger
 from settings import *


### PR DESCRIPTION
small, probably unneeded fixes, but why not.